### PR TITLE
Better random function and improved delay times

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -454,6 +454,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
+
+[[package]]
 name = "proc-macro2"
 version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -507,6 +513,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
 name = "rayon"
 version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -538,6 +574,7 @@ dependencies = [
  "futures",
  "js-sys",
  "qrcode-generator",
+ "rand",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-bindgen-test",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ lto = true
 js-sys = "0.3.22"
 wasm-bindgen = "0.2.45"
 qrcode-generator = "4.1.4"
+rand = "0.8.4"
 
 # `wee_alloc` is a tiny allocator for wasm that is only ~1K in code size
 # compared to the default allocator's ~10K. However, it is slower than the default

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,9 @@
 mod utils;
-use js_sys::Math;
 
 use qrcode_generator::QrCodeEcc;
 use utils::set_panic_hook;
 use wasm_bindgen::prelude::*;
+use rand::distributions::{Distribution, Uniform};
 
 // When the `wee_alloc` feature is enabled, use `wee_alloc` as the global
 // allocator.
@@ -187,7 +187,10 @@ impl Block {
 }
 
 fn rand_int(max: usize) -> usize {
-    (Math::random() * (max as f64)) as usize
+    let mut rng = rand::thread_rng();
+    let distribution = Uniform::from(0..max);
+
+    return distribution.sample(&mut rng);
 }
 
 fn step_down(grid: &mut Grid, block: &mut Block) -> bool {
@@ -279,7 +282,10 @@ fn clear_full_lines(score: &mut u64, grid: &mut Grid, tick_delay: &mut u64) {
     for y in 0..24 {
         if !grid[y].iter().any(|cell| *cell == 0u8) {
             *score += 1;
-            *tick_delay -= 10;
+
+            // delay function => f(x) = (time_limit * x) / (difficulty_rate + x)
+            let score_delay_rate = (400 * (*score)) / (75 + (*score));
+            *tick_delay = 400 - score_delay_rate;
 
             for y2 in (1..=y).rev() {
                 for x in 0..10 {


### PR DESCRIPTION
Why:
 - Using `Math::random()` was proving to not be random enough... For some seconds, the generated pieces would always be the same two.
 - A linear decrease for delay times was also not the best solution, as it increased difficulty very fast with no "easing". After some points, one extra point would render the game impossible.

How:
 - Adding `rand` as a dep and using [this Uniform approach](https://rust-lang-nursery.github.io/rust-cookbook/algorithms/randomness.html#generate-random-numbers-within-a-range). It returns more "variable" values for pieces and it may be faster when repeatedly generating numbers in the same range.
 - For the delay timing, using the following function `f(x) = (time_limit * x) / (difficulty_rate + x)` is a nice approach, as it increases difficulty with a higher rate in the beginning but it smoothes out for higher scores. 

The actual function plotted. It tends to 400 - the current initial value.
![Screenshot 2022-05-09 at 17 48 41](https://user-images.githubusercontent.com/25623039/167458473-f5aed936-90e3-4a1e-8987-135fc615d399.png)