### PR TITLE
Start screen with same styling as frontend

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -10,21 +10,21 @@ import("../pkg/index.js")
 
       let CELL_SIZE = Math.min(
         (window.innerHeight - 75) / 20,
-        (window.innerWidth - 20) / 10
+        (window.innerWidth - 30) / 10
       );
       const canvas = document.getElementById("tetris-canvas");
-      canvas.width = 10 * (CELL_SIZE + 2) + 2;
+      canvas.width = 10 * (CELL_SIZE + 2) + 12;
       canvas.height = 24 * (CELL_SIZE + 2) + 2;
-      canvas.minWidth = "350px";
+      canvas.style.marginTop = `${-4 * (CELL_SIZE + 2)}px`;
       let negativeMargin = CELL_SIZE * -4;
       document.body.style.transform = `translateY(${negativeMargin}px)`;
       document.body.style.marginBottom = `${negativeMargin}px`;
 
       const wrapperEl = document.querySelector("#wrapper");
 
-      wrapperEl.style.width = `${10 * (CELL_SIZE + 2) + 2}px`;
-      wrapperEl.style.height = `${24 * (CELL_SIZE + 2) + 2}px`;
-      wrapperEl.style.marginBottom = `${wrapperEl.style}px`;
+      wrapperEl.style.width = `${10 * (CELL_SIZE + 2) + 8}px`;
+      wrapperEl.style.height = `${20 * (CELL_SIZE + 2) + 6}px`;
+      wrapperEl.style.top = `${4 * (CELL_SIZE + 2) + 2}px`;
 
       const ctx = canvas.getContext("2d");
 
@@ -39,7 +39,7 @@ import("../pkg/index.js")
         7: "#64CA81", // "#ed7a5f", // "#569f1b",
       };
 
-      window.addEventListener("resize", (e) => {
+      window.addEventListener("resize", (_e) => {
         CELL_SIZE = Math.min(
           (window.innerHeight - 75) / 20,
           (window.innerWidth - 20) / 10
@@ -76,13 +76,65 @@ import("../pkg/index.js")
         }
       });
 
+      function paintPieces(color, xx, yy) {
+        if (color && color !== "#000000") {
+        //   // No Borders
+          ctx.fillStyle = color;
+          ctx.fillRect(
+            xx,
+            yy,
+            CELL_SIZE,
+            CELL_SIZE
+          );
+
+          // Only Borders
+          // ctx.strokeStyle = color;
+          // ctx.lineWidth = 4;
+          // ctx.lineJoin = 'round';
+          // ctx.fillStyle = "#000000";
+          // ctx.fillRect(
+          //   xx,
+          //   yy,
+          //   CELL_SIZE,
+          //   CELL_SIZE
+          // );
+          // ctx.strokeRect(
+          //   xx,
+          //   yy,
+          //   CELL_SIZE,
+          //   CELL_SIZE
+          // );
+
+          // Neon
+          // ctx.shadowColor = 'white';
+          // ctx.shadowBlur = 10;
+          // ctx.fillStyle = color;
+          // ctx.fillRect(
+          //   xx,
+          //   yy,
+          //   CELL_SIZE,
+          //   CELL_SIZE
+          // );
+        }
+
+        // With borders / White / Inverted
+        // ctx.fillStyle = color !== "#000000" ? "white" : "#000000";
+        // ctx.fillStyle = color;
+        // ctx.fillRect(
+        //   xx,
+        //   yy,
+        //   CELL_SIZE,
+        //   CELL_SIZE
+        // );
+      }
+
       function startScreen() {
         ctx.clearRect(0, 0, canvas.width, canvas.height);
 
         ctx.textAlign = "center";
 
         ctx.fillStyle = "#5ff2ef";
-        ctx.font = `${canvas.width < 350 ? "30px" : "40px"} 'Press Start 2P'`;
+        ctx.font = `${canvas.width < 350 ? "30px" : "50px"} 'Press Start 2P'`;
         ctx.fillText(
           "DETRIS",
           canvas.width / 2,
@@ -98,27 +150,43 @@ import("../pkg/index.js")
           canvas.width
         );
 
+        ctx.shadowColor = 'black';
+        ctx.shadowOffsetX = 4;
+        ctx.shadowOffsetY = 4;
+
         ctx.fillStyle = "#ffffff";
         ctx.font = `${canvas.width < 350 ? "16px" : "22px"} 'Press Start 2P'`;
-        ctx.fillText("Hit space", canvas.width / 2, canvas.height * 0.5);
-        ctx.fillText("to start", canvas.width / 2, canvas.height * 0.5 + 30);
+        ctx.fillText("Hit space", canvas.width / 2, canvas.height * 0.45);
+        ctx.fillText("to start", canvas.width / 2, canvas.height * 0.45 + 30);
 
-        Object.values(colors).map((color, index) => {
-          ctx.fillStyle = color;
-
-          ctx.fillRect(
-            (canvas.width - (CELL_SIZE + 4) * 8) / 2 + (CELL_SIZE + 4) * index,
-            canvas.height * 0.7,
-            CELL_SIZE,
-            CELL_SIZE
-          );
-        });
         ctx.shadowBlur = 0;
-
         ctx.fillStyle = "#ffffff";
         ctx.font = `${canvas.width < 350 ? "13px" : "15px"} 'Press Start 2P'`;
         ctx.fillText("by finiam", canvas.width / 2, canvas.height * 0.66);
 
+        ctx.shadowOffsetY = 0;
+        ctx.shadowOffsetX = 0;
+
+        const initialMap = [
+          [0, 0, 0, 0, 0, 0, 0, 0, 0, 1],
+          [0, 0, 0, 0, 0, 0, 0, 0, 5, 1],
+          [7, 7, 0, 0, 0, 0, 1, 5, 5, 1],
+          [0, 7, 0, 0, 7, 0, 1, 5, 0, 1],
+          [0, 7, 4, 0, 7, 0, 1, 6, 6, 6],
+          [5, 5, 4, 4, 7, 7, 1, 5, 5, 6],
+          [3, 5, 5, 4, 0, 6, 6, 0, 5, 5],
+          [3, 3, 2, 2, 0, 6, 6, 6, 6, 0],
+          [3, 0, 2, 2, 6, 6, 3, 3, 3, 0],
+        ]
+
+        for(let i = 0; i < initialMap.length; i++ ) {
+          for(let j = 0; j < initialMap[0].length; j++) {
+            const color = colors[initialMap[i][j]];
+            const xx = (CELL_SIZE + 2) * j + 5;
+            const yy = ((CELL_SIZE + 2) * 15) + (CELL_SIZE + 2) * i + 3;
+            paintPieces(color, xx, yy);
+          }
+        }
       }
 
       function endScreen() {
@@ -127,15 +195,15 @@ import("../pkg/index.js")
         ctx.textAlign = "center";
 
         ctx.fillStyle = "#5ff2ef";
-        ctx.font = `${canvas.width < 350 ? "30px" : "40px"} 'Press Start 2P'`;
-        ctx.fillText("Detris", canvas.width / 2, canvas.height * 0.3);
+        ctx.font = `${canvas.width < 350 ? "30px" : "50px"} 'Press Start 2P'`;
+        ctx.fillText("DETRIS", canvas.width / 2, canvas.height * 0.3);
 
         ctx.fillStyle = "#ff5050";
-        ctx.fillText("Detris", canvas.width / 2 - 8, canvas.height * 0.3 - 4);
+        ctx.fillText("DETRIS", canvas.width / 2 - 8, canvas.height * 0.3 - 4);
 
         ctx.fillStyle = "#ffffff";
         ctx.font = "22px 'Press Start 2P'";
-        ctx.fillText(`Score:${score}`, canvas.width / 2, canvas.height * 0.5);
+        ctx.fillText(`Score:${score}`, canvas.width / 2, canvas.height * 0.45);
 
         ctx.fillStyle = "#ffffff";
         ctx.font = "10px 'Press Start 2P'";
@@ -176,14 +244,10 @@ import("../pkg/index.js")
         for (let col = 0; col < 10; col++) {
           for (let row = 4; row < 24; row++) {
             const idx = col * 24 + row;
-
-            ctx.fillStyle = colors[screen[idx]] || "#0000000";
-            ctx.fillRect(
-              col * (CELL_SIZE + 2) + 2,
-              row * (CELL_SIZE + 2) + 2,
-              CELL_SIZE,
-              CELL_SIZE
-            );
+            const color = colors[screen[idx]];
+            const xx = col * (CELL_SIZE + 2) + 5;
+            const yy = row * (CELL_SIZE + 2) + 5;
+            paintPieces(color, xx, yy);
           }
         }
 

--- a/js/index.js
+++ b/js/index.js
@@ -26,21 +26,17 @@ import("../pkg/index.js")
       wrapperEl.style.height = `${24 * (CELL_SIZE + 2) + 2}px`;
       wrapperEl.style.marginBottom = `${wrapperEl.style}px`;
 
-      document.querySelector(".glass").style.top = `${
-        negativeMargin * -1 + 2
-      }px`;
-
       const ctx = canvas.getContext("2d");
 
       const colors = {
-        0: "#000000",
-        1: "#780737",
-        2: "#d29708",
-        3: "#125f03",
-        4: "#e9e2c7",
-        5: "#9b6928",
-        6: "#1c7180",
-        7: "#569f1b",
+        0: "#000000", //  FINIAM    //  RESENDE
+        1: "#ff5050", // "#00524e", // "#780737",
+        2: "#158CFA", // "#dedb7b", // "#d29708",
+        3: "#F9F25D", // "#c4b2f6", // "#125f03",
+        4: "#D05DF9", // "#4D00E5", // "#e9e2c7",
+        5: "#5DF9DD", // "#f8f1ec", // "#9b6928",
+        6: "#ffffff", // "#fcd5db", // "#1c7180",
+        7: "#64CA81", // "#ed7a5f", // "#569f1b",
       };
 
       window.addEventListener("resize", (e) => {
@@ -88,7 +84,7 @@ import("../pkg/index.js")
         ctx.fillStyle = "#5ff2ef";
         ctx.font = `${canvas.width < 350 ? "30px" : "40px"} 'Press Start 2P'`;
         ctx.fillText(
-          "Detris",
+          "DETRIS",
           canvas.width / 2,
           canvas.height * 0.3,
           canvas.width
@@ -96,8 +92,8 @@ import("../pkg/index.js")
 
         ctx.fillStyle = "#ff5050";
         ctx.fillText(
-          "Detris",
-          canvas.width / 2,
+          "DETRIS",
+          canvas.width / 2 - 4,
           canvas.height * 0.3 - 4,
           canvas.width
         );
@@ -106,9 +102,6 @@ import("../pkg/index.js")
         ctx.font = `${canvas.width < 350 ? "16px" : "22px"} 'Press Start 2P'`;
         ctx.fillText("Hit space", canvas.width / 2, canvas.height * 0.5);
         ctx.fillText("to start", canvas.width / 2, canvas.height * 0.5 + 30);
-
-        ctx.font = `${canvas.width < 350 ? "13px" : "15px"} 'Press Start 2P'`;
-        ctx.fillText("by finiam", canvas.width / 2, canvas.height * 0.9);
 
         Object.values(colors).map((color, index) => {
           ctx.fillStyle = color;
@@ -121,6 +114,11 @@ import("../pkg/index.js")
           );
         });
         ctx.shadowBlur = 0;
+
+        ctx.fillStyle = "#ffffff";
+        ctx.font = `${canvas.width < 350 ? "13px" : "15px"} 'Press Start 2P'`;
+        ctx.fillText("by finiam", canvas.width / 2, canvas.height * 0.66);
+
       }
 
       function endScreen() {

--- a/js/index.js
+++ b/js/index.js
@@ -201,6 +201,9 @@ import("../pkg/index.js")
         ctx.fillStyle = "#ff5050";
         ctx.fillText("DETRIS", canvas.width / 2 - 8, canvas.height * 0.3 - 4);
 
+        ctx.shadowColor = 'black';
+        ctx.shadowOffsetX = 4;
+        ctx.shadowOffsetY = 4;
         ctx.fillStyle = "#ffffff";
         ctx.font = "22px 'Press Start 2P'";
         ctx.fillText(`Score:${score}`, canvas.width / 2, canvas.height * 0.45);
@@ -210,6 +213,8 @@ import("../pkg/index.js")
 
         ctx.font = "15px 'Press Start 2P'";
         ctx.fillText("by finiam", canvas.width / 2, canvas.height * 0.9);
+        ctx.shadowOffsetY = 0;
+        ctx.shadowOffsetX = 0;
 
         ctx.drawImage(
           qrcode,

--- a/static/index.html
+++ b/static/index.html
@@ -5,7 +5,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
     <style>
-      @keyframes svelte-103ngm1-glow {
+      @keyframes glow {
         0% {
           filter: drop-shadow(5px 5px 20px #ffffffcc);
         }
@@ -32,7 +32,7 @@
       }
       #wrapper {
         box-shadow: inset 10px 10px 0 -5px #fff,inset -2px -2px 0 3px #fff;
-        animation: svelte-103ngm1-glow 4s ease infinite alternate-reverse;
+        animation: glow 4s ease infinite alternate-reverse;
         position: relative;
         margin: auto;
         background: #252a3d;

--- a/static/index.html
+++ b/static/index.html
@@ -5,13 +5,37 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
     <style>
+      @keyframes svelte-103ngm1-glow {
+        0% {
+          filter: drop-shadow(5px 5px 20px #ffffffcc);
+        }
+
+        100% {
+          filter: drop-shadow(10px 10px 15px #ffffff44);
+        }
+      }
       body {
-        background: #1b1b1b;
+        margin-left: auto;
+        margin-right: auto;
+        background: #111;
+      }
+      body:before {
+        content: ' ';
+        background-image: url(https://images.unsplash.com/photo-1602475063211-3d98d60e3b1f?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxzZWFyY2h8MXx8bm9pc2V8ZW58MHx8MHx8&w=1000&q=400);
+        display: block;
+        position: absolute;
+        left: 0;
+        top: 15px;
+        width: 100%;
+        height: 100%;
+        opacity: 0.3;
       }
       #wrapper {
+        box-shadow: inset 10px 10px 0 -5px #fff,inset -2px -2px 0 3px #fff;
+        animation: svelte-103ngm1-glow 4s ease infinite alternate-reverse;
         position: relative;
         margin: auto;
-        background: #1b1b1b;
+        background: #252a3d;
         border-radius: 10px;
         overflow: hidden;
       }
@@ -41,28 +65,6 @@
       canvas {
         border-radius: 10px;
       }
-      .glass {
-        position: absolute;
-        width: calc(100% - 4px);
-        right: 0;
-        left: 0;
-        margin: auto;
-        height: 100%;
-        background: linear-gradient(
-          150deg,
-          rgba(255, 255, 255, 0.25),
-          rgba(255, 255, 255, 0) 40%
-        );
-        border-radius: 10px;
-        z-index: 1000;
-        pointer-events: none;
-      }
-      .glass-end {
-        transform: rotate(180deg);
-        top: 0;
-        bottom: 2px;
-        opacity: 0.6;
-      }
     </style>
     <meta charset="utf-8">
     <title>DETRIS!</title>
@@ -70,8 +72,6 @@
   <body>
     <div id="wrapper">
       <canvas id="tetris-canvas" style="margin-left: auto; margin-right: auto; display: block"></canvas>
-       <div class="glass"></div>
-      <div class="glass glass-end"></div> 
     </div>
     <script src="index.js"></script>
   </body>


### PR DESCRIPTION
Why:
 - Making the start screen to have the same styling as the frontend in detris.finiam.com

How:
 - Adding white border, animations and respective backgrounds.
 - Fixing block placements.
 - Adding as comments the different color schemes that we'll be using.

Screenshot for reference:
![Screenshot 2022-05-11 at 12 37 01](https://user-images.githubusercontent.com/25623039/167856117-ac88c1a1-a703-4fdc-a7e6-71b0a47e6ac0.png)