### PR TITLE
Enable wee_alloc compilation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ lto = true
 
 [features]
 # If you uncomment this line, it will enable `wee_alloc`:
-#default = ["wee_alloc"]
+default = ["wee_alloc"]
 
 [dependencies]
 # The `wasm-bindgen` crate provides the bare minimum functionality needed


### PR DESCRIPTION
Why:
* `wee_alloc` was not enabled in the compile step. We could either pass
  the `--features wee_alloc` flag to the build command or enable it in
  `Cargo.toml`

How:
* Enabling the `wee_alloc` feature in the `Cargo.toml`
